### PR TITLE
Support Advanced Data Protection

### DIFF
--- a/anisette_extract/AltWindowsAnisette.cpp
+++ b/anisette_extract/AltWindowsAnisette.cpp
@@ -238,7 +238,7 @@ id __cdecl ALTClientInfoReplacementFunction(void*)
 	ObjcObject* NSString = (ObjcObject*)objc_getClass("NSString");
 	id stringInit = sel_registerName("stringWithUTF8String:");
 
-	ObjcObject* clientInfo = (ObjcObject*)((id(*)(id, SEL, const char*))objc_msgSend)(NSString, stringInit, "<MacBookPro15,1> <Mac OS X;10.15.2;19C57> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>");
+	ObjcObject* clientInfo = (ObjcObject*)((id(*)(id, SEL, const char*))objc_msgSend)(NSString, stringInit, "<MacBookPro16,1> <Mac OS X;13.1;22C65> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>");
 
 	odslog("Swizzled Client Info: " << clientInfo->description());
 


### PR DESCRIPTION
With the release of iOS/iPadOS 16.1, macOS 13.1, tvOS 16.1, and watchOS 9.2, I noticed the new Advanced Data Protection feature, allowing Apple IDs to be super secure with end-to-end encryption for more types of iCloud data.

However, enabling this feature means that you have to give up the past - if you aren't running an OS version greater than or equal to one of the above, you cannot sign into your Apple ID on that device. Naturally, this broke this setup due to spoofing a MacBookPro15,1 on 10.15.7.

This pull request is a simple fix for that issue - I changed the version to 13.1 (and also 15,1 to 16,4, so it lasts longer), and all is working well in my local tests.